### PR TITLE
Remove token replacement.

### DIFF
--- a/src/Plugin/Field/FieldType/SavedQueryField.php
+++ b/src/Plugin/Field/FieldType/SavedQueryField.php
@@ -86,12 +86,10 @@ class SavedQueryField extends FieldItemBase {
           'length' => 64
         ],
         'raw_conditions' => [
-          'type' => 'varchar',
-          'length' => 2048
+          'type' => 'text',
         ],
         'raw_sorts' => [
-          'type' => 'varchar',
-          'length' => 2048
+          'type' => 'text',
         ],
         'limit' => ['type' => 'int'],
         'interval' => ['type' => 'int'],
@@ -177,7 +175,6 @@ class SavedQueryField extends FieldItemBase {
    */
   public function getQuery() {
     $query = \Drupal::entityQuery($this->entity_type);
-    $token = \Drupal::token();
 
     if ($limit = $this->limit) {
       $query->range(0, $limit);
@@ -192,26 +189,31 @@ class SavedQueryField extends FieldItemBase {
       }
       else {
         if (is_array($condition)) {
-          $value = $token->replace($condition['value']);
+          $value = $condition['value'];
           $operator = $condition['operator'];
         }
         else {
-          $value = $token->replace($condition);
+          $value = $condition;
           $operator = '=';
-
         }
 
-        switch (strtoupper($value)) {
-          case 'IS NULL':
-            $query->exists($value);
-            break;
-          case 'IS NOT NULL':
-            $query->notExists($value);
-            break;
-          default:
-            $query->condition($key, $value, $operator);
-            break;
+        if (is_string($value)) {
+          switch (strtoupper($value)) {
+            case 'IS NULL':
+              $query->notExists($value);
+              break;
+            case 'IS NOT NULL':
+              $query->exists($value);
+              break;
+            default:
+              $query->condition($key, $value, $operator);
+              break;
+          }
         }
+        else {
+          $query->condition($key, $value, $operator);
+        }
+
       }
     }
 


### PR DESCRIPTION
We don't know if the value will be a string or array (for IN conditions), and if we pass an array into token->replace(), it breaks. So until we figure out a more elegant solution than a wall of if/thens, I propose removing token replacement for now.